### PR TITLE
Chef < 12 compatibility + configurabiity

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,14 +6,6 @@ default['chef-ruby']['source']['extension'] = 'tar.gz'
 default['chef-ruby']['source']['uri']       = 'http://ftp.ruby-lang.org/pub/ruby'
 default['chef-ruby']['source']['version']   = '2.5.0'
 
-default['chef-ruby']['source']['current']     = "#{node['chef-ruby']['source']['dir']}/current"
-default['chef-ruby']['source']['folder_name'] = "ruby-#{node['chef-ruby']['source']['version']}"
-default['chef-ruby']['source']['file_name']   = "#{node['chef-ruby']['source']['folder_name']}.#{node['chef-ruby']['source']['extension']}"
-default['chef-ruby']['source']['file_path']   = "#{Chef::Config['file_cache_path']}/#{node['chef-ruby']['source']['file_name']}"
-default['chef-ruby']['source']['folder_path'] = "#{Chef::Config['file_cache_path']}/#{node['chef-ruby']['source']['folder_name']}"
-default['chef-ruby']['source']['prefix']      = "#{node['chef-ruby']['source']['dir']}/#{node['chef-ruby']['source']['version']}"
-default['chef-ruby']['source']['url']         = "#{node['chef-ruby']['source']['uri']}/#{node['chef-ruby']['source']['file_name']}"
-
 default['chef-ruby']['source']['dependencies'] = %w[
   autoconf
   automake

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,9 +13,9 @@ recipe 'chef-ruby::configure',    'Configures the source code.'
 recipe 'chef-ruby::compile',      'Compiles the source code.'
 recipe 'chef-ruby::links',        'Makes the necessary links to binaries.'
 
-issues_url 'https://github.com/wbotelhos/chef-ruby/issues'
-source_url 'https://github.com/wbotelhos/chef-ruby'
+issues_url 'https://github.com/wbotelhos/chef-ruby/issues' if respond_to?(:issues_url)
+source_url 'https://github.com/wbotelhos/chef-ruby' if respond_to?(:source_url)
 
 supports 'ubuntu'
 
-chef_version '>= 11'
+chef_version '>= 11' if respond_to?(:chef_version)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+include_recipe 'chef-ruby::shared_variables'
 include_recipe 'chef-ruby::dependencies'
 include_recipe 'chef-ruby::download'
 include_recipe 'chef-ruby::extract'

--- a/recipes/shared_variables.rb
+++ b/recipes/shared_variables.rb
@@ -1,0 +1,8 @@
+node.default['chef-ruby']['source']['current']     = "#{node['chef-ruby']['source']['dir']}/current"
+node.default['chef-ruby']['source']['folder_name'] = "ruby-#{node['chef-ruby']['source']['version']}"
+node.default['chef-ruby']['source']['file_name']   = "#{node['chef-ruby']['source']['folder_name']}.#{node['chef-ruby']['source']['extension']}"
+node.default['chef-ruby']['source']['file_path']   = "#{Chef::Config['file_cache_path']}/#{node['chef-ruby']['source']['file_name']}"
+node.default['chef-ruby']['source']['folder_path'] = "#{Chef::Config['file_cache_path']}/#{node['chef-ruby']['source']['folder_name']}"
+node.default['chef-ruby']['source']['prefix']      = "#{node['chef-ruby']['source']['dir']}/#{node['chef-ruby']['source']['version']}"
+node.default['chef-ruby']['source']['url']         = "#{node['chef-ruby']['source']['uri']}/#{node['chef-ruby']['source']['file_name']}"
+


### PR DESCRIPTION
- check if chef responds to chef_version/issues_url/source_url (chef 11
compat)
- move variable defaults to runtime (recipe) otherwise we have to
override each one individually when using a different ruby
(configurability)

fixes #2